### PR TITLE
Fix SQL schema for associated launchers

### DIFF
--- a/resources/migrations/1.5.2.sql
+++ b/resources/migrations/1.5.2.sql
@@ -1,0 +1,106 @@
+-- --------------------------------------
+-- DROP OLD VIEWS
+-- --------------------------------------
+
+DROP VIEW vw_source_launchers;
+DROP VIEW vw_rom_launchers;
+
+-- --------------------------------------
+-- FIX TABLES DEFINITIONS: fixing FOREIGN KEY (launcher_id) REFERENCES launchers
+-- --------------------------------------
+PRAGMA foreign_keys=off;
+BEGIN TRANSACTION;
+
+ALTER TABLE romcollection_launchers RENAME TO _romcollection_launchers_old;
+ALTER TABLE source_launchers RENAME TO _source_launchers_old;
+ALTER TABLE rom_launchers RENAME TO _rom_launchers_old;
+
+CREATE TABLE romcollection_launchers(
+    romcollection_id TEXT,
+    launcher_id TEXT,
+    is_default INTEGER DEFAULT 0 NOT NULL,
+    FOREIGN KEY (romcollection_id) REFERENCES romcollections (id) 
+        ON DELETE CASCADE ON UPDATE NO ACTION,
+    FOREIGN KEY (launcher_id) REFERENCES launchers (id) 
+        ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+CREATE TABLE source_launchers(
+    source_id TEXT,
+    launcher_id TEXT,
+    is_default INTEGER DEFAULT 0 NOT NULL,
+    FOREIGN KEY (source_id) REFERENCES sources (id) 
+        ON DELETE CASCADE ON UPDATE NO ACTION,
+    FOREIGN KEY (launcher_id) REFERENCES launchers (id) 
+        ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+CREATE TABLE rom_launchers(
+    rom_id TEXT,
+    launcher_id TEXT,
+    is_default INTEGER DEFAULT 0 NOT NULL,
+    FOREIGN KEY (rom_id) REFERENCES roms (id) 
+        ON DELETE CASCADE ON UPDATE NO ACTION,
+    FOREIGN KEY (launcher_id) REFERENCES launchers (id) 
+        ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+-- --------------------------------------
+-- MIGRATE EXISTING DATA INTO NEW TABLES
+-- --------------------------------------
+INSERT INTO romcollection_launchers (romcollection_id, launcher_id, is_default)
+    SELECT romcollection_id, launcher_id, is_default
+    FROM _romcollection_launchers_old;
+
+INSERT INTO source_launchers (source_id, launcher_id, is_default)
+    SELECT source_id, launcher_id, is_default
+    FROM _source_launchers_old;
+
+INSERT INTO rom_launchers(rom_id, launcher_id, is_default)
+    SELECT rom_id, launcher_id, is_default
+    FROM _rom_launchers_old;
+
+-- --------------------------------------
+-- CLEANUP OLD TABLES
+-- --------------------------------------
+DROP TABLE _romcollection_launchers_old;
+DROP TABLE _source_launchers_old;
+DROP TABLE _rom_launchers_old;
+
+COMMIT;
+PRAGMA foreign_keys=on;
+
+-- --------------------------------------
+-- CREATE NEW VIEWS: fixing INNER JOIN launchers AS l ON sl.launcher_id = l.id
+-- --------------------------------------
+CREATE VIEW vw_source_launchers AS SELECT
+    l.id AS id,
+    l.name AS name,
+    sl.source_id,
+    a.id AS associated_addon_id,
+    a.name,
+    a.addon_id,
+    a.version,
+    a.addon_type,
+    a.extra_settings,
+    l.settings,
+    sl.is_default
+FROM source_launchers AS sl
+    INNER JOIN launchers AS l ON sl.launcher_id = l.id
+    INNER JOIN akl_addon AS a ON l.akl_addon_id = a.id;
+
+CREATE VIEW vw_rom_launchers AS SELECT
+    l.id AS id,
+    l.name AS name,
+    rl.rom_id,
+    a.id AS associated_addon_id,
+    a.name,
+    a.addon_id,
+    a.version,
+    a.addon_type,
+    a.extra_settings,
+    l.settings,
+    rl.is_default
+FROM rom_launchers AS rl
+    INNER JOIN launchers AS l ON rl.launcher_id = l.id
+    INNER JOIN akl_addon AS a ON l.akl_addon_id = a.id;

--- a/resources/schema.sql
+++ b/resources/schema.sql
@@ -178,7 +178,7 @@ CREATE TABLE IF NOT EXISTS romcollection_launchers(
     is_default INTEGER DEFAULT 0 NOT NULL,
     FOREIGN KEY (romcollection_id) REFERENCES romcollections (id) 
         ON DELETE CASCADE ON UPDATE NO ACTION,
-    FOREIGN KEY (launcher_id) REFERENCES launcher (id) 
+    FOREIGN KEY (launcher_id) REFERENCES launchers (id) 
         ON DELETE CASCADE ON UPDATE NO ACTION
 );
 
@@ -188,7 +188,7 @@ CREATE TABLE IF NOT EXISTS source_launchers(
     is_default INTEGER DEFAULT 0 NOT NULL,
     FOREIGN KEY (source_id) REFERENCES sources (id) 
         ON DELETE CASCADE ON UPDATE NO ACTION,
-    FOREIGN KEY (launcher_id) REFERENCES launcher (id) 
+    FOREIGN KEY (launcher_id) REFERENCES launchers (id) 
         ON DELETE CASCADE ON UPDATE NO ACTION
 );
 
@@ -198,7 +198,7 @@ CREATE TABLE IF NOT EXISTS rom_launchers(
     is_default INTEGER DEFAULT 0 NOT NULL,
     FOREIGN KEY (rom_id) REFERENCES roms (id) 
         ON DELETE CASCADE ON UPDATE NO ACTION,
-    FOREIGN KEY (launcher_id) REFERENCES launcher (id) 
+    FOREIGN KEY (launcher_id) REFERENCES launchers (id) 
         ON DELETE CASCADE ON UPDATE NO ACTION
 );
 
@@ -449,7 +449,7 @@ CREATE VIEW IF NOT EXISTS vw_source_launchers AS SELECT
     l.settings,
     sl.is_default
 FROM source_launchers AS sl
-    INNER JOIN launchers AS l ON sl.source_id = l.id
+    INNER JOIN launchers AS l ON sl.launcher_id = l.id
     INNER JOIN akl_addon AS a ON l.akl_addon_id = a.id;
 
 CREATE VIEW IF NOT EXISTS vw_rom_launchers AS SELECT
@@ -465,7 +465,7 @@ CREATE VIEW IF NOT EXISTS vw_rom_launchers AS SELECT
     l.settings,
     rl.is_default
 FROM rom_launchers AS rl
-    INNER JOIN launchers AS l ON rl.rom_id = l.id
+    INNER JOIN launchers AS l ON rl.launcher_id = l.id
     INNER JOIN akl_addon AS a ON l.akl_addon_id = a.id;
 
 CREATE TABLE IF NOT EXISTS akl_version(
@@ -501,4 +501,5 @@ INSERT INTO akl_migrations (migration_file, applied_version, execution_date, app
      ('1.5.0_001.sql','1.5.0',CURRENT_TIMESTAMP,1),
      ('1.5.0_002.sql','1.5.0',CURRENT_TIMESTAMP,1),
      ('1.5.0_003.sql','1.5.0',CURRENT_TIMESTAMP,1),
-     ('1.5.0_004.sql','1.5.0',CURRENT_TIMESTAMP,1);
+     ('1.5.0_004.sql','1.5.0',CURRENT_TIMESTAMP,1),
+     ('1.5.2.sql','1.5.2',CURRENT_TIMESTAMP,1);


### PR DESCRIPTION
Description:
The pull request fixes broken rom/source launcher association as according sql views have wrong join arguments.

- fixes `FOREIGN KEY (launcher_id)` in tables definitions to references `launchers` table instead of misspelled `launcher`
- fixes `vw_source_launchers` and `vw_rom_launchers` views to `INNER JOIN launchers AS l ON rl.launcher_id = l.id` instead of mistakenly set `sl.source_id`, `rl.rom_id`