### PR TITLE
fix crash when updating rom data using collection name (missing object) instead of entity_name

### DIFF
--- a/resources/lib/commands/api_commands.py
+++ b/resources/lib/commands/api_commands.py
@@ -269,7 +269,7 @@ def cmd_store_scraped_roms(args) -> bool:
             rom_repository.update_rom(rom_obj)
         uow.commit()
     
-    kodi.notify(kodi.translate(41008).format(romcollection.get_name()))
+    kodi.notify(kodi.translate(41008).format(entity_name))
     
     if metadata_is_updated:
         AppMediator.async_cmd('RENDER_VCATEGORY_VIEWS')


### PR DESCRIPTION
**Description:**
- Fixes plugin crash after scraping a rom source caused by invalid use of `romcollection` (undefined for a source) in a notification