### PR TITLE
Update Displayed ROM name after scraping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ pyrightconfig.json
 tests/assets/test_db.db
 tools/
 .fuse_hidden000*
+.DS_Store
+

--- a/resources/lib/commands/api_commands.py
+++ b/resources/lib/commands/api_commands.py
@@ -263,7 +263,8 @@ def cmd_store_scraped_roms(args) -> bool:
                 metadata_to_update,
                 assets_to_update,
                 overwrite_existing_metadata=applied_settings.overwrite_existing_meta,
-                overwrite_existing_assets=applied_settings.overwrite_existing_assets)
+                overwrite_existing_assets=applied_settings.overwrite_existing_assets,
+                update_scanned_data=not settings.getSettingAsBool('scan_ignore_scrap_title'))
             # rom_obj.scraped_with(scraper_id)
             
             rom_repository.update_rom(rom_obj)
@@ -324,7 +325,8 @@ def cmd_store_scraped_single_rom(args) -> bool:
                         metadata_to_update,
                         assets_to_update,
                         overwrite_existing_metadata=applied_settings.overwrite_existing_meta,
-                        overwrite_existing_assets=applied_settings.overwrite_existing_assets)
+                        overwrite_existing_assets=applied_settings.overwrite_existing_assets,
+                        update_scanned_data=not settings.getSettingAsBool('scan_ignore_scrap_title'))
         #  rom_obj.scraped_with(scraper_id)
         
         rom_repository.update_rom(rom)


### PR DESCRIPTION
**Description:**
- Adds actual support for the `scan_ignore_scrap_title` AKL setting: when unset, will update displayed rom name to match the scraped one instead of the file name